### PR TITLE
Keys added to component arrays. (#12)

### DIFF
--- a/src/Components/RepositoriesComponent.js
+++ b/src/Components/RepositoriesComponent.js
@@ -6,6 +6,7 @@ const RepositoriesComponent = ({ repos }) => (
     <div className="repos" style={{}}>
         {repos.map(function (repo) {
             return <RepositoryComponent
+                key={repo.node.url}
                 name={repo.node.name}
                 commits={repo.node.ref.target.history.nodes}
                 url={repo.node.url} />;

--- a/src/Components/RepositoryComponent.js
+++ b/src/Components/RepositoryComponent.js
@@ -7,6 +7,7 @@ const RepositoryComponent = ({ name, commits, url }) => (
         <a href={url}> {name} </a>
         {commits.map(function (commit) {
             return <CommitComponent
+                key={commit.abbreviatedOid}
                 abbreviatedOid={commit.abbreviatedOid}
                 message={commit.message}
                 committedDate={commit.committedDate} />;


### PR DESCRIPTION
## Summary

This resolves issue #12.

*****

I added the `key` property to both `RepositoryComponent` and `RepositoriesComponent` when they map over their respective arrays.

For `RepositoryComponent`, I set the key to `commit.abbreviatedOid`, and for `RepositoriesComponent`, I set the key to `node.url`.

I set the `RepositoriesComponent` key to `node.url` instead of `node.name` because it may be possible for the `node.name` property to not be unique, while `node.url` should always be unique.

## Test plan

I assumed the snapshots would record the `key` property, but they either do not or I failed to find the option to make them do so.

*****

The `key` property is on each object under `tree.props.children`, so they could be looped through and each `key` property could be compared to the `props.url` property.

I did not add this as a test though, because I did not want to add testing that might be considered bad practice if Snapshots did support the `key` property and I had simply not been able to find it.

*****

I would add the above proposed method of testing if requested.